### PR TITLE
fix: fix spigot 1.16.1 world dir regression

### DIFF
--- a/ci/master/cloudbuild.yaml
+++ b/ci/master/cloudbuild.yaml
@@ -9,5 +9,5 @@ steps:
   - name: gcr.io/cloud-builders/gsutil
     args:
       - "cp"
-      - "build/distributions/paper-mc_1.16.1-3_amd64.deb"
+      - "build/distributions/paper-mc_1.16.1-4_amd64.deb"
       - "gs://serena-minecraft-platform-debian-repo/"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 versionProperty=1.16.1
-releaseProperty=3
+releaseProperty=4
 paperDownloadURL=https://papermc.io/api/v1/paper/1.16.1/117/download

--- a/opt/minecraft/shutdown.sh
+++ b/opt/minecraft/shutdown.sh
@@ -9,7 +9,7 @@ echo "$time backing up world $worldName"
 rcon-cli --config $rconConfigPath say server is being shutdown for backups please reconnect in 10 minutes
 sleep 10
 rcon-cli --config $rconConfigPath stop
-sleep 90
+sleep 10
 tar -czvf "/minecraft-backup/world-$time.tar.gz" "$minecraftPath/"
 gsutil cp "/minecraft-backup/world-$time.tar.gz" gs://tiede-minecraft-world-bucket/
 echo "uploaded world backup"

--- a/opt/minecraft/start.sh
+++ b/opt/minecraft/start.sh
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-/usr/bin/java -Xmx2048M -Xms2048M -jar /opt/minecraft/paper.jar nogui
+/usr/bin/java -Xmx2048M -Xms2048M -jar /opt/minecraft/paper.jar nogui --world-container /minecraft-data


### PR DESCRIPTION
this most recent update broke the world container config
option within the spigot.yaml file. This setting must
be configured via the commandline flag per 
[jira issue](https://hub.spigotmc.org/jira/browse/SPIGOT-5824).